### PR TITLE
Handlers not sent when using Composer autoload

### DIFF
--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -629,6 +629,9 @@ class Request
      */
     public static function init($method = null, $mime = null)
     {
+        // Setup our handlers, can call it here as it's idempotent
+        Bootstrap::init();
+	
         // Setup the default template if need be
         if (!isset(self::$_template))
             self::_initializeDefaults();


### PR DESCRIPTION
I have no idea if this is the best way to fix it, but I figured as registerHandlers is idempotent it doesn't really matter. When using httpful via Composer, the Bootstrap.php file isn't loaded at all so the handlers never get registered. This makes sure they're registered every time a request is made.
