### PR TITLE
Fix: Headers req->camelCase => amel-Case

### DIFF
--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -570,7 +570,7 @@ class Request
             $method = substr($method, 4);
 
         // Precede upper case letters with dashes, uppercase the first letter of method
-        $header =  substr(ucwords(preg_replace('/([A-Z])/', '-$1', $method)), 1);
+        $header = ucwords(preg_replace('/([a-z0-9])([A-Z])/', '$1-$2', $method));
         $this->addHeader($header, $args[0]);
         return $this;
     }


### PR DESCRIPTION
Calling with lowercase first word caused header to be stored as amel-Case instead of Camel-Case

I hope there are no cookies with name from other then aphanum characters.
