### PR TITLE
Added storage for headers

### DIFF
--- a/src/Httpful/Headers.php
+++ b/src/Httpful/Headers.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Httpful;
+
+final class Headers implements \ArrayAccess {
+
+	private $headers;
+
+	private function __construct($headers)
+	{
+		$this->headers = $headers;
+	}
+
+	public static function fromString($string)
+    {
+        $lines = preg_split("/(\r|\n)+/", $string, -1, PREG_SPLIT_NO_EMPTY);
+        array_shift($lines); // HTTP HEADER
+        $headers = array();
+        foreach ($lines as $line) {
+        	dump($line);
+            list($name, $value) = explode(':', $line, 2);
+            $headers[strtolower(trim($name))] = trim($value);
+        }
+        return new self($headers);
+    }
+
+	public function offsetExists($offset)
+	{
+		return isset($this->headers[strtolower($offset)]);
+	}
+
+	public function offsetGet($offset)
+	{
+		if (isset($this->headers[$name = strtolower($offset)])) {
+			return $this->headers[$name];
+		}
+	}
+
+	public function offsetSet($offset, $value)
+	{
+		throw new \Exception("Headers are read-only.");
+	}
+
+	public function offsetUnset($offset)
+	{
+		throw new \Exception("Headers are read-only.");
+	}
+
+	public function toArray()
+	{
+		return $this->headers;
+	}
+
+}

--- a/src/Httpful/Response.php
+++ b/src/Httpful/Response.php
@@ -35,7 +35,7 @@ class Response
         $this->raw_body     = $body;
 
         $this->code         = $this->_parseCode($headers);
-        $this->headers      = $this->_parseHeaders($headers);
+        $this->headers      = Headers::fromString($headers);
 
         $this->_interpretHeaders();
 
@@ -101,23 +101,6 @@ class Response
         }
 
        return Httpful::get($parse_with)->parse($body);
-    }
-
-    /**
-     * Parse text headers from response into
-     * array of key value pairs
-     * @return array parse headers
-     * @param string $headers raw headers
-     */
-    public function _parseHeaders($headers)
-    {
-        $headers = preg_split("/(\r|\n)+/", $headers, -1, \PREG_SPLIT_NO_EMPTY);
-        $parse_headers = array();
-        for ($i = 1; $i < count($headers); $i++) {
-            list($key, $raw_value) = explode(':', $headers[$i], 2);
-            $parse_headers[trim($key)] = trim($raw_value);
-        }
-        return $parse_headers;
     }
 
     public function _parseCode($headers)


### PR DESCRIPTION
More practical storage for headers
Header names are converted to lower case to avoid character case problems.
Undefined headers return null to avoid isset checks.
