### PR TITLE
Fix: Headers req->camelCase => amel-Case

### DIFF
--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -570,7 +570,7 @@ class Request
             $method = substr($method, 4);
 
         // Precede upper case letters with dashes, uppercase the first letter of method
-        $header =  substr(ucwords(preg_replace('/([A-Z])/', '-$1', $method)), 1);
+        $header = ucwords(implode('-', preg_split('/([A-Z][^A-Z]*)/', $method, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY)));
         $this->addHeader($header, $args[0]);
         return $this;
     }


### PR DESCRIPTION
Calling with lowercase first word caused header to be stored as amel-Case instead of Camel-Case

For this i had to go into black magic section of php library. Cause I would hate to do it with loop :)
