### PR TITLE
fix form serialization to always use & as separator

### DIFF
--- a/src/Httpful/Handlers/FormHandler.php
+++ b/src/Httpful/Handlers/FormHandler.php
@@ -25,6 +25,6 @@ class FormHandler extends MimeHandlerAdapter
      */
     public function serialize($payload)
     {
-        return http_build_query($payload);
+        return http_build_query($payload, null, '&');
     }
 }


### PR DESCRIPTION
the php arg_separator.output setting can change the output of http_build_query.

it's pretty common to set it to "&amp;amp;" which will break posting form data using httpful.
