### PR TITLE
Added Except header to Request.php to eliminate HTTP 1.1 Continue header

### DIFF
--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -748,7 +748,7 @@ class Request
         $headers[] = $accept;
 	// https://github.com/nategood/httpful/issues/37
 	// Except header removes any HTTP 1.1 Continue from response headers 
-        $headers[] = 'Except:'; 
+        $headers[] = 'Expect:'; 
 
         foreach ($this->headers as $header => $value) {
             $headers[] = "$header: $value";


### PR DESCRIPTION
Adding the Except header to the Request class will eliminate an HTTP 1.1 Continue header. This can be regarded as a hotfix since people using HTTPFul will currently not be able to Post to HTTP 1.1 servers.  
