### PR TITLE
Added timeout method to be able to timeout http calls

### DIFF
--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -756,7 +756,7 @@ class Request
         $headers = array();
         // https://github.com/nategood/httpful/issues/37
         // Except header removes any HTTP 1.1 Continue from response headers
-        $headers[] = 'Except:';
+        $headers[] = 'Expect:';
 
         if (!isset($this->headers['User-Agent'])) {
             $headers[] = $this->buildUserAgent();


### PR DESCRIPTION
Added the timeout method and integrated it in to _curlPrep so that code like

```
     $response = \Httpful\Request::$method($uri)
    ->authenticateWith($username, $password)
    ->sendsJson()
    ->expectsHtml()
    ->body(json_encode($data))
    ->timeout(1)
    ->send();
```

only waits for the amount specified in the timeout function
