### PR TITLE
Update src/Httpful/Response/Headers.php

### DIFF
--- a/src/Httpful/Response/Headers.php
+++ b/src/Httpful/Response/Headers.php
@@ -18,7 +18,16 @@ final class Headers implements \ArrayAccess, \Countable {
         $headers = array();
         foreach ($lines as $line) {
             list($name, $value) = explode(':', $line, 2);
-            $headers[strtolower(trim($name))] = trim($value);
+            if (array_key_exists(strtolower(trim($name)), $headers)) {
+                    // See HTTP RFC Sec 4.2 Paragraph 5
+	                // http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
+	                // If a header appears more than once, it must also be able to
+	                // be represented as a single header with a comma-separated
+	                // list of values.  We transform accordingly. 
+				$headers[strtolower(trim($name))] .= '||' . trim($value);
+		            } else {
+		                 $headers[strtolower(trim($name))] = trim($value);
+		            }
         }
         return new self($headers);
     }


### PR DESCRIPTION
Update src/Httpful/Response/Headers.php
If a header appears more than once, it must also be able to  be represented as a single header with a comma-separated list of values.  We transform accordingly.

Well, the cookies have commas on them on the date field so i'm using a double pipe for delimiter.

Set-Cookie: cookie_1=42de533-b4d2-4f28-8982-ccda555061a8; Domain=www.mydomain.com; Expires=Tue, 12-Feb-13 17:10:28 GMT; Path=/; HttpOnly 
Set-Cookie: cookie_2=somevalue; Domain=www.mydomain.com; Expires=Tue, 12-Feb-13 15:10:28 GMT; Path=/; HttpOnly
