### PR TITLE
Custom Accept Header

### DIFF
--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -764,14 +764,17 @@ class Request
 
         $headers[] = "Content-Type: {$this->content_type}";
 
-        // http://pretty-rfc.herokuapp.com/RFC2616#header.accept
-        $accept = 'Accept: */*; q=0.5, text/plain; q=0.8, text/html;level=3;';
+        // allow custom Accept header if set
+        if (!isset($this->headers['Accept'])) {
+            // http://pretty-rfc.herokuapp.com/RFC2616#header.accept
+            $accept = 'Accept: */*; q=0.5, text/plain; q=0.8, text/html;level=3;';
 
-        if (!empty($this->expected_type)) {
-            $accept .= "q=0.9, {$this->expected_type}";
+            if (!empty($this->expected_type)) {
+                $accept .= "q=0.9, {$this->expected_type}";
+            }
+
+            $headers[] = $accept;
         }
-
-        $headers[] = $accept;
 
         foreach ($this->headers as $header => $value) {
             $headers[] = "$header: $value";

--- a/tests/Httpful/HttpfulTest.php
+++ b/tests/Httpful/HttpfulTest.php
@@ -184,6 +184,18 @@ X-My-Header:Value2\r\n";
         $r->_curlPrep();
         $this->assertContains('application/json', $r->raw_headers);
     }
+
+    function testCustomAccept()
+    {
+        $accept = 'application/api-1.0+json';
+        $r = Request::get('http://example.com/')
+            ->addHeader('Accept', $accept);
+
+        $r->_curlPrep();
+        $this->assertContains($accept, $r->raw_headers);
+        $this->assertEquals($accept, $r->headers['Accept']);
+    }
+
     function testUserAgent()
     {
         $r = Request::get('http://example.com/')


### PR DESCRIPTION
First off I really :heart: the simplicity and interface of httpful!

Please consider this patch for inclusion. My particular use case requires the request header "Accept" to be set to a certain value. Currently, httpful's default behavior is to set the Accept header and only allows users to append to the default values.

My patch simply excludes this default behavior if the "Accept" header is set. Otherwise behaves the same way with the current default values.

Thanks!
