### PR TITLE
Parsing HTTP Code according to RFC

### DIFF
--- a/src/Httpful/Response.php
+++ b/src/Httpful/Response.php
@@ -133,7 +133,7 @@ class Response
 
     public function _parseCode($headers)
     {
-        $parts = explode(' ', substr($headers, 0, strpos($headers, "\n")));
+        $parts = explode(' ', substr($headers, 0, strpos($headers, "\r\n")));
         if (count($parts) < 2 || !is_numeric($parts[1])) {
             throw new \Exception("Unable to parse response code from HTTP response due to malformed response");
         }


### PR DESCRIPTION
I have encountered this error during testing mine apps communicating over HTTP.
Mine setup was Nginx + PHP 5.4.12 on Win.
On 500 response status was not parsed properly and Httpful threw an exception.

I still don't fully get how the http code parsing could work without this patch so I would appreciate if someone could **revise the proposed change.**
I can provide testing data for exception if necessary (don't have time right now).

OT: Anyhow I would expect from this library to take more simpler approach by checking for number till first space. (checking only for `500` instead of `500 Server Error...\n')
