### PR TITLE
Squid bug

### DIFF
--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -823,7 +823,7 @@ class Request
         $this->raw_headers .= "Host: $host\r\n";
         $this->raw_headers .= \implode("\r\n", $headers);
         $this->raw_headers .= "\r\n";
-debug($headers);
+
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 
         if (isset($this->payload)) {


### PR DESCRIPTION
This pull request solve a problem with Squid proxy. In squid if no content-length is set in header the request is rejected. A workaround is to set content-length to 0 in header.

Sorry for the messy pull request, it has three commits rather then only one.
