### PR TITLE
Add proper Content-Length based off of the request body's length

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,8 @@
         "psr-0": {
             "Httpful": "src/"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "*"
     }
 }


### PR DESCRIPTION
Make sure to use serialized_payload length as Content-Length if the request has a body
