### PR TITLE
close cURL resource, and free up system resources automatically

### DIFF
--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -216,6 +216,8 @@ class Request
         $body = array_pop($response);
         $headers = array_pop($response);
 
+        curl_close($this->_ch);
+
         return new Response($body, $headers, $this);
     }
     public function sendIt()


### PR DESCRIPTION
Hi @nategood,
we have problems with keeping connection alive. Our script calls requests via your Httpful repeatedly in our job client/server application (http://gearman.org) and requested server refuses any further request due to too many connections. Is this pull request OK for you?
