### PR TITLE
Null is also a valid JSON data.

### DIFF
--- a/src/Httpful/Handlers/JsonHandler.php
+++ b/src/Httpful/Handlers/JsonHandler.php
@@ -22,7 +22,7 @@ class JsonHandler extends MimeHandlerAdapter
     public function parse($body)
     {
         $body = $this->stripBom($body);
-        if (empty($body))
+        if (empty($body) || $body === 'null')
             return null;
         $parsed = json_decode($body, $this->decode_as_array);
         if (is_null($parsed) && 'null' !== strtolower($body))


### PR DESCRIPTION
Hi Nate Good,

I update the JsonHandler::parse function.
I run into "Unable to parse response as JSON" when the WebService return "null" in the body.
In this case, we can conform to JSON valid data for null.

Thank you Nate Good.
