### PR TITLE
Introduces support for the baked in PHP HTTP Server in 5.4

### DIFF
--- a/tests/Httpful/HttpfulTest.php
+++ b/tests/Httpful/HttpfulTest.php
@@ -19,9 +19,11 @@ use Httpful\Http;
 use Httpful\Response;
 use Httpful\Handlers\JsonHandler;
 
+define('TEST_SERVER', WEB_SERVER_HOST . ':' . WEB_SERVER_PORT);
+
 class HttpfulTest extends \PHPUnit_Framework_TestCase
 {
-    const TEST_SERVER = '127.0.0.1:8008';
+    const TEST_SERVER = TEST_SERVER;
     const TEST_URL = 'http://127.0.0.1:8008';
     const TEST_URL_400 = 'http://127.0.0.1:8008/400';
 
@@ -492,18 +494,21 @@ Transfer-Encoding: chunked\r\n", $request);
         $this->assertNotEquals($prev, $new);
     }
 
-    public function testHasProxyWithoutProxy() {
+    public function testHasProxyWithoutProxy()
+    {
         $r = Request::get('someUrl');
         $this->assertFalse($r->hasProxy());
     }
 
-    public function testHasProxyWithProxy() {
+    public function testHasProxyWithProxy()
+    {
         $r = Request::get('some_other_url');
         $r->useProxy('proxy.com');
         $this->assertTrue($r->hasProxy());
     }
 
-    public function testParseJSON() {
+    public function testParseJSON()
+    {
         $handler = new JsonHandler();
 
         $bodies = array(
@@ -524,10 +529,28 @@ Transfer-Encoding: chunked\r\n", $request);
         }
         $this->fail('Expected an exception to be thrown due to invalid json');
     }
+
+    // /**
+    //  * Skeleton for testing against the 5.4 baked in server
+    //  */
+    // public function testLocalServer()
+    // {
+    //     if (!defined('WITHOUT_SERVER') || (defined('WITHOUT_SERVER') && !WITHOUT_SERVER)) {
+    //         // PHP test server seems to always set content type to application/octet-stream
+    //         // so force parsing as JSON here
+    //         Httpful::register('application/octet-stream', new \Httpful\Handlers\JsonHandler());
+    //         $response = Request::get(TEST_SERVER . '/test.json')
+    //             ->sendsAndExpects(MIME::JSON);
+    //         $response->send();
+    //         $this->assertTrue(...);
+    //     }
+    // }
 }
 
-class DemoMimeHandler extends \Httpful\Handlers\MimeHandlerAdapter {
-    public function parse($body) {
+class DemoMimeHandler extends \Httpful\Handlers\MimeHandlerAdapter
+{
+    public function parse($body)
+    {
         return 'custom parse';
     }
 }

--- a/tests/bootstrap-server.php
+++ b/tests/bootstrap-server.php
@@ -1,0 +1,37 @@
+<?php
+
+$php_version = phpversion();
+$php_major = floatval(substr($php_version, 0, 3));
+
+if ($php_major < 5.4) {
+	define('WITHOUT_SERVER', true);
+} else {
+	// Command that starts the built-in web server
+	$command = sprintf('php -S %s:%d -t %s >./server.log 2>&1 & echo $!', WEB_SERVER_HOST, WEB_SERVER_PORT, WEB_SERVER_DOCROOT);
+
+	// Execute the command and store the process ID
+	$output = array();
+	exec($command, $output, $exit_code);
+
+	// sleep for a second to let server come up
+	sleep(1);
+	$pid = (int) $output[0];
+
+	// check server.log to see if it failed to start
+	$server_logs = file_get_contents("./server.log");
+	if (strpos($server_logs, "Fail") !== false) {
+		// server failed to start for some reason
+		print "Failed to start server! Logs:" . PHP_EOL . PHP_EOL;
+		print_r($server_logs);
+		exit(1);
+	}
+
+	echo sprintf('%s - Web server started on %s:%d with PID %d', date('r'), WEB_SERVER_HOST, WEB_SERVER_PORT, $pid) . PHP_EOL;
+
+	register_shutdown_function(function() {
+		// cleanup after ourselves -- remove log file, shut down server
+		global $pid;
+		unlink("./server.log");
+		posix_kill($pid, SIGKILL);
+	});
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,7 +1,14 @@
-<phpunit>
-    <testsuite name="Httpful">
-        <directory>.</directory>
-    </testsuite>
+<phpunit bootstrap="./bootstrap-server.php">
+    <testsuites>
+        <testsuite name="Httpful">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <const name="WEB_SERVER_HOST" value="localhost" />
+        <const name="WEB_SERVER_PORT" value="1349" />
+        <const name="WEB_SERVER_DOCROOT" value="./static" />
+    </php>
     <logging>
         <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
     </logging>

--- a/tests/static/test.json
+++ b/tests/static/test.json
@@ -1,0 +1,1 @@
+{"foo": "bar", "baz": false}


### PR DESCRIPTION
Pulled in from @zbuc s work in his proposed logger pull request
Requires PHP 5.4 but this can now be useful for integration testing
