### PR TITLE
Add support for milliseconds timeout

### DIFF
--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -851,7 +851,11 @@ class Request
         }
 
         if ($this->hasTimeout()) {
-            curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeout);
+            if (defined('CURLOPT_TIMEOUT_MS')) {
+                curl_setopt($ch, CURLOPT_TIMEOUT_MS, $this->timeout * 1000);
+            } else {
+                curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeout);
+            }
         }
 
         if ($this->follow_redirects) {


### PR DESCRIPTION
Hey!

According to the PHPDoc, the timeout can accept a float so, this PR adds support for milliseconds timeout. Basically, `CURLOPT_TIMEOUT_MS` has been introduced in curl 7.16.2 so, if it is defined, it is better to rely on it as it is more precise otherwise we rely on `CURLOPT_TIMEOUT` as it is currently.
