### PR TITLE
Added which uri curl could not connect to

### DIFF
--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -204,11 +204,11 @@ class Request
             if ($curlErrorNumber = curl_errno($this->_ch)) {
                 $curlErrorString = curl_error($this->_ch);
                 $this->_error($curlErrorString);
-                throw new ConnectionErrorException('Unable to connect: ' . $curlErrorNumber . ' ' . $curlErrorString);
+                throw new ConnectionErrorException('Unable to connect to "'.$this->uri.'": ' . $curlErrorNumber . ' ' . $curlErrorString);
             }
 
-            $this->_error('Unable to connect.');
-            throw new ConnectionErrorException('Unable to connect.');
+            $this->_error('Unable to connect to "'.$this->uri.'".');
+            throw new ConnectionErrorException('Unable to connect to "'.$this->uri.'".');
         }
 
         $info = curl_getinfo($this->_ch);


### PR DESCRIPTION
First, thanks for the nice library. 

I use it in a project for multiple REST calls. It was a bit of hassle to track down which call could not connect to which URI. So I added the URI to the ConnectionErrorException message to make clearer.