### PR TITLE
Verify if is a string httpful/src/Httpful/Request.php on line 953

### DIFF
--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -950,7 +950,9 @@ class Request
     public function _determineLength($str)
     {
         if (function_exists('mb_strlen')) {
-            return mb_strlen($str, '8bit');
+            if (is_string($str)) {
+                return mb_strlen($str, '8bit');
+            }
         } else {
             return strlen($str);
         }


### PR DESCRIPTION
Resolves the warning:

PHP Warning:  mb_strlen() expects parameter 1 to be string, array given in httpful/src/Httpful/Request.php on line 953