### PR TITLE
Refining Mime type detection

### DIFF
--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -399,7 +399,10 @@ class Request
             if (function_exists('curl_file_create')) {
                 $this->payload[$key] = curl_file_create($file, $mimeType);
             } else {
-                $this->payload[$key] = '@' . $file . ';type=' . $mimeType;
+                $this->payload[$key] = '@' . $file;
+	            if ($mimeType) {
+		            $this->payload[$key] .= ';type=' . $mimeType;
+	            }
             }
         }
         $this->sendsType(Mime::UPLOAD);


### PR DESCRIPTION
It can happen, that the Fileinfo extension can't detect the Mime type of a file.
Then, the appended type will send an empty type to the server.
Sometimes, it's not what you want.