### PR TITLE
Added case insensitivity to proxy header handler

### DIFF
--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -215,7 +215,7 @@ class Request
         $info = curl_getinfo($this->_ch);
 
         // Remove the "HTTP/1.x 200 Connection established" string and any other headers added by proxy
-        $proxy_regex = "/HTTP\/1\.[01] 200 Connection established.*?\r\n\r\n/s";
+        $proxy_regex = "/HTTP\/1\.[01] 200 Connection established.*?\r\n\r\n/si";
         if ($this->hasProxy() && preg_match($proxy_regex, $result)) {
             $result = preg_replace($proxy_regex, '', $result);
         }


### PR DESCRIPTION
Currently some proxies (Fiddler2 being a notable example) send a 200
Connection Established header instead of 200 Connection established
(note capitalisation)

This fix modifies the request handler to be case insensitive so as to
handle this scenario.

(go easy, this is my first ever pull request on github)