### PR TITLE
added support for http_proxy environment variable

### DIFF
--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -509,7 +509,12 @@ class Request
      */
     public function hasProxy()
     {
-        return isset($this->additional_curl_opts[CURLOPT_PROXY]) && is_string($this->additional_curl_opts[CURLOPT_PROXY]);
+        /* We must be aware that proxy variables could come from environment also.
+           In curl extension, http proxy can be specified not only via CURLOPT_PROXY option, 
+           but also by environment variable called http_proxy.
+        */
+        return isset($this->additional_curl_opts[CURLOPT_PROXY]) && is_string($this->additional_curl_opts[CURLOPT_PROXY]) ||
+            getenv("http_proxy");
     }
 
     /**

--- a/tests/Httpful/HttpfulTest.php
+++ b/tests/Httpful/HttpfulTest.php
@@ -554,6 +554,14 @@ Transfer-Encoding: chunked\r\n", $request);
         $this->assertTrue($r->hasProxy());
     }
 
+    public function testHasProxyWithEnvironmentProxy()
+    {
+        putenv('http_proxy=http://127.0.0.1:300/');
+        $r = Request::get('some_other_url');
+        $this->assertTrue($r->hasProxy());
+    }
+
+
     public function testParseJSON()
     {
         $handler = new JsonHandler();

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -8,6 +8,7 @@
         <const name="WEB_SERVER_HOST" value="localhost" />
         <const name="WEB_SERVER_PORT" value="1349" />
         <const name="WEB_SERVER_DOCROOT" value="./static" />
+	<env name="http_proxy" value="" />
     </php>
     <logging>
         <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>


### PR DESCRIPTION
By using curl extension, the http proxy can be specified not only via CURLOPT_PROXY option, but also by environment variable called http_proxy.
