### PR TITLE
parseWith support for any callable method

### DIFF
--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -610,11 +610,11 @@ class Request
 
     /**
      * Use a custom function to parse the response.
-     * @param \Closure $callback Takes the raw body of
+     * @param Callable $callback Takes the raw body of
      *    the http response and returns a mixed
      * @return Request
      */
-    public function parseWith(\Closure $callback)
+    public function parseWith(Callable $callback)
     {
         $this->parse_callback = $callback;
         return $this;
@@ -622,10 +622,10 @@ class Request
 
     /**
      * @see Request::parseResponsesWith()
-     * @param \Closure $callback
+     * @param Callable $callback
      * @return Request
      */
-    public function parseResponsesWith(\Closure $callback)
+    public function parseResponsesWith(Callable $callback)
     {
         return $this->parseWith($callback);
     }

--- a/tests/Httpful/HttpfulTest.php
+++ b/tests/Httpful/HttpfulTest.php
@@ -268,6 +268,32 @@ X-My-Header:Value2\r\n";
         $this->assertEquals(1, $response->body->array[0]);
     }
 
+    function testResponseParseWithInline()
+    {
+        $req = Request::init()->sendsAndExpects(Mime::JSON)
+            ->parseWith(function($body) {
+                return json_decode($body);
+            });
+        $response = new Response(self::SAMPLE_JSON_RESPONSE, self::SAMPLE_JSON_HEADER, $req);
+
+        $this->assertEquals("value", $response->body->key);
+        $this->assertEquals("value", $response->body->object->key);
+        $this->assertInternalType('array', $response->body->array);
+        $this->assertEquals(1, $response->body->array[0]);
+    }
+
+    function testResponseParseWithCallable()
+    {
+        $req = Request::init()->sendsAndExpects(Mime::JSON)
+            ->parseWith(json_decode);
+        $response = new Response(self::SAMPLE_JSON_RESPONSE, self::SAMPLE_JSON_HEADER, $req);
+
+        $this->assertEquals("value", $response->body->key);
+        $this->assertEquals("value", $response->body->object->key);
+        $this->assertInternalType('array', $response->body->array);
+        $this->assertEquals(1, $response->body->array[0]);
+    }
+
     function testXMLResponseParse()
     {
         $req = Request::init()->sendsAndExpects(Mime::XML);


### PR DESCRIPTION
Currently parseWith only supports inline Closure types, I would like to support passing existing functions (in other namespaces) as the custom response body parser. This PR covers that use case and adds two tests for inline and any callable function.