### PR TITLE
#227 unset curl handle after it has been closed

### DIFF
--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -204,6 +204,7 @@ class Request
         $response = $this->buildResponse($result);
 
         curl_close($this->_ch);
+        unset($this->_ch);
 
         return $response;
     }


### PR DESCRIPTION
Resolves issue 227 (making request objects reusable)
