### PR TITLE
Allow Request to be extended by changing class name 'Request' to static

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
-    "name": "bluehaoran/httpful",
+    "name": "nategood/httpful",
     "description": "A Readable, Chainable, REST friendly, PHP HTTP Client",
     "homepage": "http://github.com/nategood/httpful",
     "license": "MIT",
     "keywords": ["http", "curl", "rest", "restful", "api", "requests"],
-    "version": "0.2.21-alpha",
+    "version": "0.2.20",
     "authors": [
         {
             "name": "Nate Good",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "bluehaoran/httpful",
+    "name": "nategood/httpful",
     "description": "A Readable, Chainable, REST friendly, PHP HTTP Client",
     "homepage": "http://github.com/nategood/httpful",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
-    "name": "nategood/httpful",
+    "name": "bluehaoran/httpful",
     "description": "A Readable, Chainable, REST friendly, PHP HTTP Client",
     "homepage": "http://github.com/nategood/httpful",
     "license": "MIT",
     "keywords": ["http", "curl", "rest", "restful", "api", "requests"],
-    "version": "0.2.20",
+    "version": "0.2.21-alpha",
     "authors": [
         {
             "name": "Nate Good",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "homepage": "http://github.com/nategood/httpful",
     "license": "MIT",
     "keywords": ["http", "curl", "rest", "restful", "api", "requests"],
-    "version": "0.2.20",
+    "version": "0.2.21-alpha",
     "authors": [
         {
             "name": "Nate Good",

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
     "name": "bluehaoran/httpful",
-    "description": "A Readable, Chainable, REST friendly, PHP HTTP Client, forked from NateGood",
+    "description": "A Readable, Chainable, REST friendly, PHP HTTP Client",
     "homepage": "http://github.com/nategood/httpful",
     "license": "MIT",
     "keywords": ["http", "curl", "rest", "restful", "api", "requests"],
-    "version": "0.2.21-alpha",
+    "version": "0.2.20",
     "authors": [
         {
             "name": "Nate Good",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "nategood/httpful",
-    "description": "A Readable, Chainable, REST friendly, PHP HTTP Client",
+    "name": "bluehaoran/httpful",
+    "description": "A Readable, Chainable, REST friendly, PHP HTTP Client, forked from NateGood",
     "homepage": "http://github.com/nategood/httpful",
     "license": "MIT",
     "keywords": ["http", "curl", "rest", "restful", "api", "requests"],

--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -13,7 +13,7 @@ use Httpful\Exception\ConnectionErrorException;
  * itself very nicely to "chaining".  You will see several "alias"
  * methods: more readable method definitions that wrap
  * their more concise counterparts.  You will also notice
- * no public constructor.  This two adds to the readability
+ * no public constructor.  This too adds to the readability
  * and "chainabilty" of the library.
  *
  * @author Nate Good <me@nategood.com>

--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -760,7 +760,7 @@ class Request
         // recusion.  Do not use this syntax elsewhere.
         // It goes against the whole readability
         // and transparency idea.
-        self::$_template = new Request(array('method' => Http::GET));
+        self::$_template = new static(array('method' => Http::GET));
 
         // This is more like it...
         self::$_template
@@ -811,7 +811,7 @@ class Request
         if (!isset(self::$_template))
             self::_initializeDefaults();
 
-        $request = new Request();
+        $request = new static();
         return $request
                ->_setDefaults()
                ->method($method)


### PR DESCRIPTION
New PR because I didn't target Dev last time. 

Fixed a typo, and added static dereferencing, allowing Request to be extended (so I could add automatic HMAC signing on send()).
