### PR TITLE
Add PHPDocs for __call methods in Request.

### DIFF
--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -17,6 +17,31 @@ use Httpful\Exception\ConnectionErrorException;
  * and "chainabilty" of the library.
  *
  * @author Nate Good <me@nategood.com>
+ * 
+ * @method self sendsJson()
+ * @method self sendsXml()
+ * @method self sendsForm()
+ * @method self sendsPlain()
+ * @method self sendsText()
+ * @method self sendsUpload()
+ * @method self sendsHtml()
+ * @method self sendsXhtml()
+ * @method self sendsJs()
+ * @method self sendsJavascript()
+ * @method self sendsYaml()
+ * @method self sendsCsv()
+ * @method self expectsJson()
+ * @method self expectsXml()
+ * @method self expectsForm()
+ * @method self expectsPlain()
+ * @method self expectsText()
+ * @method self expectsUpload()
+ * @method self expectsHtml()
+ * @method self expectsXhtml()
+ * @method self expectsJs()
+ * @method self expectsJavascript()
+ * @method self expectsYaml()
+ * @method self expectsCsv()
  */
 class Request
 {


### PR DESCRIPTION
Add PHPDoc for magic method __call methods `sendsMime()` and `expectsMime()`. Helps minimize warnings when using the library in strict IDE environments .

See [here for more information](https://manual.phpdoc.org/HTMLSmartyConverter/PHP/phpDocumentor/tutorial_tags.method.pkg.html).