### PR TITLE
Add new Exception

### DIFF
--- a/src/Httpful/Exception/JsonParseException.php
+++ b/src/Httpful/Exception/JsonParseException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Httpful\Exception;
+
+class JsonParseException extends \Exception
+{
+}

--- a/src/Httpful/Handlers/JsonHandler.php
+++ b/src/Httpful/Handlers/JsonHandler.php
@@ -6,6 +6,8 @@
 
 namespace Httpful\Handlers;
 
+use Httpful\Exception\JsonParseException;
+
 class JsonHandler extends MimeHandlerAdapter
 {
     private $decode_as_array = false;
@@ -27,7 +29,7 @@ class JsonHandler extends MimeHandlerAdapter
             return null;
         $parsed = json_decode($body, $this->decode_as_array);
         if (is_null($parsed) && 'null' !== strtolower($body))
-            throw new \Exception("Unable to parse response as JSON");
+            throw new JsonParseException('Unable to parse response as JSON: ' . json_last_error_msg());
         return $parsed;
     }
 

--- a/tests/Httpful/HttpfulTest.php
+++ b/tests/Httpful/HttpfulTest.php
@@ -570,8 +570,8 @@ Transfer-Encoding: chunked\r\n", $request);
 
         try {
             $result = $handler->parse('invalid{json');
-        } catch(\Exception $e) {
-            $this->assertEquals('Unable to parse response as JSON', $e->getMessage());
+        } catch (\Httpful\Exception\JsonParseException $e) {
+            $this->assertEquals('Unable to parse response as JSON: ' . json_last_error_msg(), $e->getMessage());
             return;
         }
         $this->fail('Expected an exception to be thrown due to invalid json');


### PR DESCRIPTION
If response can not parse to json, should be throw precise exception (JsonParseException) instead universal exception.