### PR TITLE
Allow curl to decode the response

### DIFF
--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -952,6 +952,14 @@ class Request
             $headers[] = $accept;
         }
 
+        // Set Accept-Encoding to empty string if not provided
+        if (!isset($this->headers['Accept-Encoding'])) {
+            $this->headers['Accept-Encoding'] = '';
+        }
+
+        // Set curl encoding based on Accept-Encoding
+        curl_setopt($ch, CURLOPT_ENCODING, $this->headers['Accept-Encoding']);
+
         // Solve a bug on squid proxy, NONE/411 when miss content length
         if (!isset($this->headers['Content-Length']) && !$this->isUpload()) {
             $this->headers['Content-Length'] = 0;

--- a/tests/Httpful/HttpfulTest.php
+++ b/tests/Httpful/HttpfulTest.php
@@ -266,6 +266,20 @@ X-My-Header:Value2\r\n";
         $this->assertTrue($r->hasDigestAuth());
     }
 
+    function testAcceptEncoding()
+    {
+        $r = Request::get('http://example.com/');
+        $r->_curlPrep();
+
+        $this->assertEquals('', $r->headers['Accept-Encoding']);
+
+        $accept_encoding = 'gzip, compress, br';
+        $r->addHeader('Accept-Encoding', $accept_encoding);
+        $r->_curlPrep();
+        
+        $this->assertEquals($accept_encoding, $r->headers['Accept-Encoding']);
+    }
+
     function testJsonResponseParse()
     {
         $req = Request::init()->sendsAndExpects(Mime::JSON);


### PR DESCRIPTION
This PR is trying to fix the issue with a compressed response, in my case, it was "gzip" compression. For example, if we get "Content-Encoding: gzip" from the server side we will get the exception with the message "Unable to parse the response as JSON: Control character error, possibly incorrectly encoded"

The point is to allow curl to decode the response automatically if it is compressed and then later every parser can continue to do their jobs without any issue.

Please let me know what do you think.

Thanks!