### PR TITLE
Hotfix http2 downgrade failure aws alb

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
-    "name": "nategood/httpful",
+    "name": "criterion9/httpful",
     "description": "A Readable, Chainable, REST friendly, PHP HTTP Client",
     "homepage": "http://github.com/nategood/httpful",
     "license": "MIT",
     "keywords": ["http", "curl", "rest", "restful", "api", "requests"],
-    "version": "0.3.2",
+    "version": "0.3.2.1",
     "authors": [
         {
             "name": "Nate Good",
@@ -15,6 +15,10 @@
     "require": {
         "php": ">=7.2",
         "ext-curl": "*"
+    },
+    "provide"{
+        "nategood/httpful": "0.3.2.1"
+    
     },
     "autoload": {
         "psr-0": {

--- a/src/Httpful/Request.php
+++ b/src/Httpful/Request.php
@@ -970,6 +970,7 @@ class Request
         $this->raw_headers .= "\r\n";
 
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+	curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
 
         if ($this->_debug) {
             curl_setopt($ch, CURLOPT_VERBOSE, true);


### PR DESCRIPTION
Requests are automatically upgraded to HTTP2 with curl library changes. This change forces HTTP1.1 connections as a hotfix until the maintainer addresses the underlying issue.