### PR TITLE
Fix passing null as string

### DIFF
--- a/src/Httpful/Handlers/FormHandler.php
+++ b/src/Httpful/Handlers/FormHandler.php
@@ -6,7 +6,7 @@
 
 namespace Httpful\Handlers;
 
-class FormHandler extends MimeHandlerAdapter 
+class FormHandler extends MimeHandlerAdapter
 {
     /**
      * @param string $body
@@ -18,13 +18,13 @@ class FormHandler extends MimeHandlerAdapter
         parse_str($body, $parsed);
         return $parsed;
     }
-    
+
     /**
      * @param mixed $payload
      * @return string
      */
     public function serialize($payload): string
     {
-        return http_build_query($payload, null, '&');
+        return http_build_query($payload, "", '&');
     }
 }


### PR DESCRIPTION
Fixes a PHP deprecation warning on PHP >= 8.1: `http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated`.

Just set the parameter to `""` instead of `null`.